### PR TITLE
Translation of the tip about translated parts

### DIFF
--- a/website/app_data/i18n/api.pt-BR.json
+++ b/website/app_data/i18n/api.pt-BR.json
@@ -19,5 +19,5 @@
     "related_links": "Links Relacionados",
     "source_code": "Código Fonte",
     "quick_tip": "Dica Rápida",
-    "only_code_is_translated": "Code comments are in Português to help you use the class, however most class and function descriptions have not yet been translated."
+    "only_code_is_translated": "Comentários de código estão em Português para ajudá-lo na utilização da classe, entretanto, a maioria das descrições de classes e funções não foram traduzidas."
 }


### PR DESCRIPTION
"only_code_is_translated" added as a Quick tip section that by Conrad to clear to Portuguese speakers what part of the page is translated."