### PR TITLE
PHPStan config fixes and simplification

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,6 +31,7 @@
 parameters:
     checkMissingIterableValueType: false
     inferPrivatePropertyTypeFromConstructor: false
+    treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -
             message: '#Access to an undefined property#'
@@ -55,38 +56,12 @@ parameters:
                 - src/Application.php
                 - src/AppMin.php
         -
-            message: '#Result of \|\| is always true#'
-            paths:
-                - src/Data/Validator.php
-                - src/Security/Crypto/JWT.php
-                - src/Web/Request.php
-                - src/Web/Response.php
-        -
             message: '#Comparison operation ">" between int<min, 0>\|false and 0 is always false.#'
             path: src/Application.php
         -
             message: '#Strict comparison using === between string and null will always evaluate to false#'
             paths:
                 - src/Security/Crypto/FileEncryption.php
-        -
-            # The items on the next error are based on phpstan assuming a user always passes a string if the PHPDoc Block
-            # specifies a string. These are error that can be matched based on [is_string()].
-            # These branches are reachable as confirmed in Unit Tests.
-            message: '#Else branch is unreachable because previous condition is always true#'
-            paths:
-                - src/Lang/I18N.php
-                - src/Lang/L10N.php
-        -
-            # These errors are similar ot the above where phpstan assumes user cannot pass invalid input.
-            # And some of these are related to mixed types not being handled by phpstan.
-            # These conditions are reachable as confirmed in Unit Tests.
-            message: '#Strict comparison using (.*) will always evaluate to false#'
-            paths:
-                - src/Lang/I18N.php
-                - src/Lang/L10N.php
-                - src/Security/Crypto/FileEncryption.php
-                - src/Net/HttpClient.php
-                - src/Security/Crypto/AbstractCrypto.php
         -
             # According to PHP Docs int should be passed and it has been confirmed to work
             # and used on production sites.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,13 +36,6 @@ parameters:
             message: '#Access to an undefined property#'
             path: src/Data/AbstractVendorDatabase.php
         -
-            message: '#Undefined variable#'
-            paths:
-                - src/Data/AbstractVendorDatabase.php
-                - src/Templates/error-cli.php
-                - src/Templates/error.php
-                - src/Templates/html-template.php
-        -
             message: '#Variable \$e might not be defined#'
             paths:
                 - src/Templates/error-cli.php
@@ -50,13 +43,6 @@ parameters:
         -
             message: '#PHPDoc tag @param has invalid value#'
             path: src/Data/AbstractDatabase.php
-        -
-            message: '#PHPDoc tag @param for parameter (s+) with type array\|null is not subtype of native type array#'
-            paths:
-                - src/Data/Database.php
-                - src/Data/Log/AbstractLogger.php
-                - src/Environment/DotEnv.php
-                - src/Net/HttpClient.php
         -
             message: '#Binary operation (.+) results in an error#'
             path: src/Net/IP.php
@@ -76,20 +62,8 @@ parameters:
                 - src/Web/Request.php
                 - src/Web/Response.php
         -
-            message: '#Result of && is always false#'
-            paths:
-                - src/Encoding/Base64Url.php
-                - src/Net/IP.php
-                - src/Polyfill/hex_compat.php
-                - src/Templates/error.php
-        -
             message: '#Comparison operation ">" between int<min, 0>\|false and 0 is always false.#'
             path: src/Application.php
-        -
-            message: '#Unreachable statement - code above always terminates#'
-            paths:
-                - src/Net/SmtpClient.php
-                - src/Security/Crypto/AbstractCrypto.php
         -
             message: '#Strict comparison using === between string and null will always evaluate to false#'
             paths:
@@ -113,12 +87,6 @@ parameters:
                 - src/Security/Crypto/FileEncryption.php
                 - src/Net/HttpClient.php
                 - src/Security/Crypto/AbstractCrypto.php
-        -
-            # Below check is logic based on differnces between 32-bit and 64-bit builds of PHP.
-            message: '#Comparison operation (.*) between int and 2147483647 is always true#'
-            paths:
-                - src/Security/Crypto/Encryption.php
-                - src/Security/Crypto/SignedData.php
         -
             # According to PHP Docs int should be passed and it has been confirmed to work
             # and used on production sites.
@@ -239,11 +207,6 @@ parameters:
                 - src/Lang/Time.php
                 - src/Lang/I18N.php
                 - src/Net/HttpClient.php
-        -
-            message: '#Cannot assign offset#'
-            paths:
-                - src/Net/Config.php
-                - src/Net/SmtpClient.php
         -
             message: '#Property (.+) does not accept#'
             path: src/Net/HttpClient.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -51,7 +51,7 @@ parameters:
             message: '#PHPDoc tag @param has invalid value#'
             path: src/Data/AbstractDatabase.php
         -
-            message: '#PHPDoc tag @param for parameter (s+) with type array|null is not subtype of native type array#'
+            message: '#PHPDoc tag @param for parameter (s+) with type array\|null is not subtype of native type array#'
             paths:
                 - src/Data/Database.php
                 - src/Data/Log/AbstractLogger.php
@@ -64,12 +64,12 @@ parameters:
             message: '#Call to an undefined method object#'
             path: src/Templates/error-cli.php
         -
-            message: '#Strict comparison using === between string|false and null will always evaluate to false.#'
+            message: '#Strict comparison using === between string\|false and null will always evaluate to false.#'
             paths:
                 - src/Application.php
                 - src/AppMin.php
         -
-            message: '#Result of || is always true#'
+            message: '#Result of \|\| is always true#'
             paths:
                 - src/Data/Validator.php
                 - src/Security/Crypto/JWT.php
@@ -83,7 +83,7 @@ parameters:
                 - src/Polyfill/hex_compat.php
                 - src/Templates/error.php
         -
-            message: '#Comparison operation ">" between int<min, 0>|false and 0 is always false.#'
+            message: '#Comparison operation ">" between int<min, 0>\|false and 0 is always false.#'
             path: src/Application.php
         -
             message: '#Unreachable statement - code above always terminates#'


### PR DESCRIPTION
Hi! 👋 

Following our discussion over at https://github.com/github/super-linter/issues/122, I looked at your PHPStan config and found some areas to improve.

* https://github.com/fastsitephp/fastsitephp/commit/421037c60f65dd6f4f8a106640d0a867cdc775b3 basically meant that previously large amounts of errors were ignored unbeknownst to you. Recent PHPStan versions print these situations as warnings so you'd find out about it.
* Some ignored errors are no longer present in the list: https://github.com/fastsitephp/fastsitephp/commit/bb4e4d1e866ff8f1f69b35d6063261e156fbf5dd
* This (relatively recent) setting is able to get rid of some errors you must have ignored previously as well: https://github.com/fastsitephp/fastsitephp/commit/c938452debb7592c68625e201d3634e7de2acc35

Because of the first point your analysis now contains 77 errors (https://gist.github.com/ondrejmirtes/da0a20d4d0c6e20019698f4df91fe523) you previously didn't know about. Feel free to take advantage of the [baseline feature](https://phpstan.org/user-guide/baseline) to generate the ignores for you instead of needing to manually curate the list.

Additionally, I'd recommend you to:

1) Add `phpstan/phpstan` to `require-dev` of your composer.json instead of needing to manually download it every time.
2) Run PHPStan and your tests in some CI system like GitHub Actions or Travis CI.